### PR TITLE
Windows support and various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning per [SemVer](https://semver.org/).
 
+## [1.0.4] — 2026-08-08
+
+### Added
+- ChatGPT custom connector support on the same Funnel URL: RFC 7591 `POST /register` (DCR), public-client token auth (`none`), and allowlisted `https://chatgpt.com/connector/oauth/…` redirects. Panel section 2 documents Claude + ChatGPT side by side.
+
+### Changed
+- OAuth metadata advertises `registration_endpoint` and `token_endpoint_auth_methods_supported: ["none","client_secret_post"]`. Claude’s pre-issued Client ID/Secret path is unchanged.
+
 ## [1.0.3] — 2026-08-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning per [SemVer](https://semver.org/).
 
+## [1.0.3] — 2026-08-08
+
+### Fixed
+- Windows: `npm start` no longer dies on Unix-only env syntax in `package.json`, `spawn npx ENOENT`, or macOS-only `open` / `osascript` / `pgrep`.
+- Windows: hub is started via `node …/mcp-hub/dist/cli.js` (no `npx` shim); panel accepts `C:\…` absolute paths; Chrome CDP launch uses `chrome.exe`; folder picker uses WinForms; `search_content` uses a JS walker when `grep` is missing; shell allowlist ignores `\` as a dangerous char and adds `where` / `findstr`.
+
+### Changed
+- Supported platforms: macOS and Windows. Shipped `mcp-hub.config.json` uses `${userHome}${pathSeparator}…` so home-relative roots expand correctly on both.
+
 ## [1.0.2] — 2026-08-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Give Claude on the **web** (claude.ai) read/edit access to files and a whitelisted shell on your local machine, over HTTPS via Tailscale Funnel, gated by OAuth 2.1. No desktop app, no device install.
 
-Version: **1.0.2** ([CHANGELOG.md](CHANGELOG.md)) · License: MIT · macOS only.
+Version: **1.0.3** ([CHANGELOG.md](CHANGELOG.md)) · License: MIT · macOS & Windows.
 
 <img width="288" height="438" alt="Screenshot 2026-08-07 at 23 25 12" src="https://github.com/user-attachments/assets/8947f948-c012-4802-8936-28d2495586b1" />
 
@@ -58,7 +58,8 @@ OAuth (not token-in-URL) is used because claude.ai always attempts Dynamic Clien
 
 <img width="649" height="689" alt="image" src="https://github.com/user-attachments/assets/c4d50b51-fb2f-4e13-9ee4-4214068d8b3f" />
 
-- macOS with Node.js installed
+- macOS or Windows with Node.js installed
+- On Windows: [Git for Windows](https://git-scm.com/download/win) recommended so the default shell allowlist (`ls`, `grep`, `find`, …) and akidevrule's `install.sh` resolve on PATH
 - Tailscale (one-time setup):
   1. [Install Tailscale](https://tailscale.com/download) and sign in (app or `brew install tailscale`, either works as long as `tailscale` is on PATH)
   2. Enable [Funnel](https://tailscale.com/docs/features/tailscale-funnel) for your tailnet: free on every plan, a one-time toggle via the `login.tailscale.com/f/funnel` link `npm start` prints if it isn't on yet
@@ -73,6 +74,7 @@ aki-mcp-sv/
 ├── mcp-hub.config.json         # shipped default, uses ${MCP_DATA_DIR}/${HOME} placeholders
 ├── scripts/
 │   ├── start.js                 # orchestrates mcp-hub + gatekeeper
+│   ├── platform.js              # Windows/macOS helpers (spawn hub, open URL, find Chrome)
 │   ├── gatekeeper.js             # OAuth-gated reverse proxy, public port
 │   ├── oauth.js                  # minimal authorization server (DCR skipped)
 │   ├── streamable-bridge.js      # Streamable HTTP shim <-> mcp-hub's legacy SSE transport
@@ -121,7 +123,7 @@ Nothing needs preparing beforehand; `npm start` handles it:
 - Prints the 4 values you need: **Remote MCP server URL**, **OAuth Client ID**, **OAuth Client Secret** (paste into claude.ai), and **Passphrase** (enter on the confirmation page when you hit Connect).
 - Opens the **control panel** at `http://127.0.0.1:9998/?t=<token>`, with 8 sections in the order you need them: Tailscale, connector, allowed folders, shell allowlist, akidevrule, connector prompt, utilities, Chrome.
 
-The default allowed root is your **home directory** (`$HOME`): the one folder guaranteed to exist on any machine and to hold the projects you actually want Claude to reach. Add/remove folders from **panel section 3**: the "Choose folder…" button opens macOS's native picker (multi-select in one pass); saving restarts the hub automatically. To change the root from the start: `MCP_DATA_DIR=/other/path npm start`.
+The default allowed root is your **home directory** (`$HOME` / `%USERPROFILE%`): the one folder guaranteed to exist on any machine and to hold the projects you actually want Claude to reach. Add/remove folders from **panel section 3**: the "Choose folder…" button opens the native picker (macOS: multi-select in one pass; Windows: one folder per click); saving restarts the hub automatically. To change the root from the start: `MCP_DATA_DIR=/other/path npm start` (or `set MCP_DATA_DIR=D:\work` then `npm start` on Windows cmd).
 
 Beyond `$MCP_DATA_DIR`, the filesystem server is also granted `~/.aki` (where akidevrule deploys) and `~/.claude`, so claude.ai can read your **native** `CLAUDE.md` and skill router the same way Claude Code does, with no copying or staging.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # aki-mcp-sv
 
-Give Claude on the **web** (claude.ai) read/edit access to files and a whitelisted shell on your local machine, over HTTPS via Tailscale Funnel, gated by OAuth 2.1. No desktop app, no device install.
+Give Claude on the **web** (claude.ai) and **ChatGPT** read/edit access to files and a whitelisted shell on your local machine, over HTTPS via Tailscale Funnel, gated by OAuth 2.1. No desktop app, no device install.
 
-Version: **1.0.3** ([CHANGELOG.md](CHANGELOG.md)) · License: MIT · macOS & Windows.
+Version: **1.0.4** ([CHANGELOG.md](CHANGELOG.md)) · License: MIT · macOS & Windows.
 
 <img width="288" height="438" alt="Screenshot 2026-08-07 at 23 25 12" src="https://github.com/user-attachments/assets/8947f948-c012-4802-8936-28d2495586b1" />
 
 <img width="498" height="390" alt="Screenshot 2026-08-07 at 23 06 42" src="https://github.com/user-attachments/assets/94800561-b799-49ce-a7ab-08a52b6dbfde" />
 
-**Contents:** [Why this exists](#why-this-exists) · [Architecture](#architecture) · [Requirements](#requirements) · [Directory layout](#directory-layout) · [Install](#install) · [Run](#run) · [Exposing via Tailscale](#exposing-via-tailscale) · [Connecting from Claude web](#connecting-from-claude-web) · [Finding files](#finding-files) · [Security](#security)
+**Contents:** [Why this exists](#why-this-exists) · [Architecture](#architecture) · [Requirements](#requirements) · [Directory layout](#directory-layout) · [Install](#install) · [Run](#run) · [Exposing via Tailscale](#exposing-via-tailscale) · [Connecting from Claude web](#connecting-from-claude-web) · [Connecting from ChatGPT](#connecting-from-chatgpt) · [Finding files](#finding-files) · [Security](#security)
 
 ## Why this exists
 
@@ -27,8 +27,8 @@ This project targets a different scenario: exposing local access to Claude **on 
 ## Architecture
 
 ```
-Claude web (claude.ai)
-      │  HTTPS + OAuth 2.1 (DCR skipped — self-issued client ID/secret)
+Claude web / ChatGPT
+      │  HTTPS + OAuth 2.1 (Claude: paste client ID/secret; ChatGPT: DCR self-register)
       ▼
 Tailscale Funnel        (https://your-machine.your-tailnet.ts.net)
       │
@@ -52,7 +52,7 @@ panel.js       — 127.0.0.1:9998, never exposed via Funnel
 
 `mcp-hub` ships its own unauthenticated admin REST API (`/api/*`) on the same port. `gatekeeper.js` exists specifically so that never reaches the internet (`docs/plan/init.md`).
 
-OAuth (not token-in-URL) is used because claude.ai always attempts Dynamic Client Registration regardless of configuration (`docs/ref/oauth-research-2026-08-07.md`).
+OAuth (not token-in-URL) is used because claude.ai always attempts Dynamic Client Registration regardless of configuration (`docs/ref/oauth-research-2026-08-07.md`). ChatGPT also expects OAuth; this server advertises `/register` (RFC 7591 DCR) so ChatGPT can self-register while Claude can keep using the pre-issued Client ID/Secret.
 
 ## Requirements
 
@@ -161,6 +161,17 @@ Why not token-in-URL: `docs/ref/claude-connector.md`, `docs/ref/oauth-research-2
 
 claude.ai connects and calls 14 tools: `filesystem__*`, `search__find_path`, `search__search_content`, `shell__run_cmd`.
 
+## Connecting from ChatGPT
+
+Needs ChatGPT Plus/Pro (or Business/Enterprise/Edu) with **Developer mode** for custom connectors.
+
+1. ChatGPT → Settings → Apps & Connectors (or Security) → enable **Developer mode**
+2. Create a custom connector / app → paste the same MCP URL (`https://your-machine.your-tailnet.ts.net/mcp`)
+3. Auth: **OAuth** (no Client ID/Secret paste — ChatGPT self-registers via `POST /register`)
+4. Enter the same **passphrase** on the confirmation page
+
+Same folder allowlist and shell allowlist as Claude. Restart `npm start` after upgrading so gatekeeper advertises `registration_endpoint`.
+
 ### Chrome control
 
 Chrome only opens its debug port **at launch**; an already-running Chrome without that flag can't be attached to and must be quit and reopened. The panel splits this into two actions: "Connect Chrome" never closes anything (opens Chrome if it's not running, warns and stops if it's running without the flag), while quitting Chrome sits behind its own explicit button.
@@ -181,7 +192,7 @@ Use `search__find_path`, not `filesystem__search_files`, to locate a file or dir
 
 ## Security
 
-Minimal OAuth 2.1, Dynamic Client Registration skipped on purpose (self-issued client ID/secret instead of letting claude.ai self-register). Full writeup (real request flow, the two actual barriers, known limits): `docs/ref/security-model.md`.
+Minimal OAuth 2.1: Claude uses a pre-issued confidential Client ID/Secret; ChatGPT uses DCR (`POST /register`) as a public client (`token_endpoint_auth_method: none`) with `chatgpt.com` redirect URIs allowlisted. Full writeup: `docs/ref/security-model.md`.
 
 - `$MCP_DATA_DIR` (default `$HOME`) is the filesystem server's main root, plus `~/.aki` and `~/.claude` (for native rule files), fixed at process start; changing it via the panel restarts the hub. `~/.claude` is granted at the folder level, so session tokens and chat history inside it are also in the connector's reach (a known tradeoff, removable from the panel).
 - The shell MCP is hand-written (`shell-mcp.js`), enforcing the allowlist in code (`execFile`, never through a shell, `; & | \`` blocked). The default set is read-only, defined in `allowlist.js`; the panel shows exactly that set as your starting point for edits, saved to `~/.aki/mcpsv/setting.json` → `shell.allowlist`. **Any command you add is your own responsibility**: adding a write command (e.g. `git commit`) crosses the "read-only" boundary this project ships with by default. A command can run in any directory under the allowed roots via the `cwd` parameter, used instead of `cd`/`-C` to target a specific repo.

--- a/docs/ref/security-model.md
+++ b/docs/ref/security-model.md
@@ -1,41 +1,42 @@
-# Security model — minimal OAuth 2.1 (DCR skipped)
+# Security model — minimal OAuth 2.1 (Claude + ChatGPT)
 
-Updated 2026-08-07 — replaces the earlier token-in-URL scheme, after token-in-URL was found to hit a claude.ai OAuth/DCR bug (detail + sources: `docs/ref/oauth-research-2026-08-07.md`).
+Updated 2026-08-08 — Claude keeps a pre-issued confidential client; ChatGPT uses RFC 7591 DCR on the same server.
 
 ## Current auth architecture
 
 ```
-claude.ai
+claude.ai / ChatGPT
    │  GET /.well-known/oauth-protected-resource, /.well-known/oauth-authorization-server
-   │  (endpoint discovery, no registration needed — no /register)
+   │  ChatGPT (and optionally Claude): POST /register  (DCR)
    ▼
-gatekeeper.js  ── /authorize  → confirmation page, requires the right passphrase (~/.aki/mcpsv/passphrase.txt)
-               ── /token      → exchanges a code (PKCE S256) for access + refresh tokens
-               ── /mcp        → requires a valid `Authorization: Bearer <access_token>`
-                                  wrong/missing → 401 + WWW-Authenticate, correct → forward to mcp-hub
+gatekeeper.js  ── /register  → RFC 7591 (redirect URIs: Claude callback + chatgpt.com/connector/oauth/*)
+               ── /authorize → confirmation page, requires passphrase (~/.aki/mcpsv/passphrase.txt)
+               ── /token     → PKCE S256; confidential clients need client_secret, DCR public clients use none
+               ── /mcp       → Bearer access token required, else 401 + WWW-Authenticate → mcp-hub
 ```
 
-`scripts/oauth.js` keeps all state (auth codes, access tokens, refresh tokens) **in memory** — no DB, nothing persists across a restart.
+Pre-issued Claude credentials live in `~/.aki/mcpsv/oauth-client.json`. DCR clients (ChatGPT) persist in `~/.aki/mcpsv/oauth-dcr-clients.json`. Access/refresh tokens persist in `~/.aki/mcpsv/tokens.json`.
 
-## Why Dynamic Client Registration (DCR) is skipped
+## Client registration
 
-claude.ai defaults to attempting client self-registration (`POST /register`) before connecting — this server has no such endpoint, and `/.well-known/oauth-authorization-server` **deliberately** does not advertise `registration_endpoint`. Instead, `client_id`/`client_secret` are generated once (`~/.aki/mcpsv/oauth-client.json`), printed at `npm start`, and pasted by hand into the dialog's Advanced settings — exactly the "pre-registered client credentials" mechanism Anthropic's own docs recognize as a valid way to skip DCR entirely.
+- **Claude (pre-registered)**: Client ID/Secret printed by `npm start`, pasted into Advanced settings. Redirect URI fixed to `https://claude.ai/api/mcp/auth_callback`. Auth method: `client_secret_post`.
+- **ChatGPT (DCR)**: ChatGPT calls `POST /register` with its `https://chatgpt.com/connector/oauth/{id}` redirect URI. Auth method: `none` (PKCE only). Only Claude/ChatGPT redirect URI patterns are accepted — arbitrary third-party redirects are rejected.
 
 ## The 2 layers that actually block unauthorized access
 
-1. **Passphrase at `/authorize`** (`~/.aki/mcpsv/passphrase.txt`, 10 random characters from a 32-character unambiguous alphabet — `abcdefghjkmnpqrstuvwxyz23456789`, ~50-bit entropy) — anyone who doesn't know the passphrase can't get past the consent step, so no auth code is ever issued. Shortened from the original 256-bit hex on 2026-08-07 to be easier to type/copy by hand — 50-bit entropy still keeps the "no rate-limit needed" reasoning below intact. **Deliberately not a bare Approve button with no passphrase**: considered and rejected — `POST /authorize` is a public endpoint exposed through Funnel, and a simulated request (`curl`) can send the exact same fields a button click would, so the server can't tell them apart; a "button" with no accompanying secret provides no real protection.
-2. **PKCE S256** — an access token is only issued to the exact client whose `code_challenge` matches the `code_verifier` sent to `/token`; this blocks anyone who intercepts the authorization code in transit (without the verifier, the code is useless).
+1. **Passphrase at `/authorize`** (`~/.aki/mcpsv/passphrase.txt`, 10 random characters from a 32-character unambiguous alphabet — `abcdefghjkmnpqrstuvwxyz23456789`, ~50-bit entropy) — anyone who doesn't know the passphrase can't get past the consent step, so no auth code is ever issued. **Deliberately not a bare Approve button with no passphrase**: `POST /authorize` is public via Funnel; a simulated request can't be distinguished from a button click without a secret.
+2. **PKCE S256** — an access token is only issued to the exact client whose `code_challenge` matches the `code_verifier` sent to `/token`.
 
-The real `mcp-hub` still only listens on loopback `19999`, and `/api/*` is never forwarded — unchanged from the original design.
+The real `mcp-hub` still only listens on loopback `19999`, and `/api/*` is never forwarded.
 
-## Real limitations of this approach
+## Real limitations
 
-- **No refresh token rotation** — acceptable because this is a confidential client (has a client_secret), not a public client under DCR/CIMD (the MCP spec's rotation rule only applies to public clients).
-- **Restarting `npm start` loses every issued session** — access/refresh tokens live only in RAM. claude.ai will need to "Connect" again. An acceptable tradeoff for a single-user MVP run in the foreground on demand.
-- **No rate-limiting on `/authorize`** — acceptable because the 50-bit passphrase makes brute-forcing infeasible, the same entropy reasoning previously applied to token-in-URL.
+- **No refresh token rotation** for the pre-registered confidential Claude client (spec rotation rule targets public clients).
+- **No rate-limiting on `/authorize`** — acceptable because the 50-bit passphrase makes brute-forcing infeasible.
+- **DCR creates one stored client per ChatGPT connector instance** — delete `oauth-dcr-clients.json` (and restart) to revoke those registrations.
 
 ## Cross-references
-- `docs/ref/oauth-research-2026-08-07.md` — full research behind this decision, sources
-- `docs/ref/claude-connector.md` — the real fields on claude.ai's dialog
+- `docs/ref/oauth-research-2026-08-07.md` — research that drove the Claude pre-registered path
+- `docs/ref/claude-connector.md` — fields on claude.ai's dialog
 - `docs/plan/init.md` — original architecture decisions
-- `scripts/oauth.js`, `scripts/gatekeeper.js` — actual implementation
+- OpenAI Apps SDK auth: https://developers.openai.com/apps-sdk/build/auth

--- a/mcp-hub.config.json
+++ b/mcp-hub.config.json
@@ -2,17 +2,17 @@
   "mcpServers": {
     "filesystem": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "${MCP_DATA_DIR}", "${HOME}/.aki", "${HOME}/.claude"]
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "${MCP_DATA_DIR}", "${userHome}${pathSeparator}.aki", "${userHome}${pathSeparator}.claude"]
     },
     "search": {
       "command": "node",
       "args": ["./scripts/search-mcp.js"],
-      "env": { "MCP_DATA_DIR": "${MCP_DATA_DIR},${HOME}/.aki,${HOME}/.claude" }
+      "env": { "MCP_DATA_DIR": "${MCP_DATA_DIR},${userHome}${pathSeparator}.aki,${userHome}${pathSeparator}.claude" }
     },
     "shell": {
       "command": "node",
       "args": ["./scripts/shell-mcp.js"],
-      "env": { "MCP_DATA_DIR": "${MCP_DATA_DIR},${HOME}/.aki,${HOME}/.claude" }
+      "env": { "MCP_DATA_DIR": "${MCP_DATA_DIR},${userHome}${pathSeparator}.aki,${userHome}${pathSeparator}.claude" }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,13 @@
 {
   "name": "mcp-local",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-local",
+      "version": "1.0.2",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "mcp-hub": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-local",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "description": "Give Claude on the web (claude.ai) local filesystem/search/shell access over Tailscale Funnel + OAuth 2.1 — whitelist-only shell (unlike Desktop Commander's blocklist), no desktop app or device lock-in required",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-local",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "description": "Give Claude on the web (claude.ai) local filesystem/search/shell access over Tailscale Funnel + OAuth 2.1 — whitelist-only shell (unlike Desktop Commander's blocklist), no desktop app or device lock-in required",
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "start": "MCP_DATA_DIR=\"${MCP_DATA_DIR:-$HOME}\" node ./scripts/start.js"
+    "start": "node ./scripts/start.js"
   },
   "dependencies": {
     "mcp-hub": "^4.2.1",

--- a/scripts/allowlist.js
+++ b/scripts/allowlist.js
@@ -3,12 +3,21 @@ import fs from 'node:fs';
 import { SETTINGS_PATH } from './userdata.js';
 
 // null = any subcommand allowed; array = only those subcommands. Curated to read-only binaries.
-export const DEFAULT_ALLOWLIST = {
+// Unix tools work as-is on macOS/Linux and also on Windows when Git for Windows usr\bin is on PATH.
+const UNIX_DEFAULT = {
   ls: null, cat: null, pwd: null, find: null, grep: null, head: null, tail: null,
   wc: null, file: null, stat: null, tree: null, ps: null, df: null, du: null,
   whoami: null, uname: null,
   git: ['status', 'log', 'diff', 'show'],
 };
+
+const WIN_EXTRA = {
+  where: null,
+  findstr: null,
+};
+
+export const DEFAULT_ALLOWLIST =
+  process.platform === 'win32' ? { ...UNIX_DEFAULT, ...WIN_EXTRA } : UNIX_DEFAULT;
 
 export function readSettings() {
   try {

--- a/scripts/chrome.js
+++ b/scripts/chrome.js
@@ -1,14 +1,11 @@
 // Minimal CDP client, no dependency: Node 22 ships WebSocket. Chrome opens its debug port only at launch, so quitting a running Chrome is unavoidable — and confined to restartChrome(); everything else here never closes anything.
-import { execFile } from 'node:child_process';
 import { setTimeout as sleep } from 'node:timers/promises';
+import { IS_MAC, IS_WIN, execCapture, findChrome } from './platform.js';
 
 const CDP_PORT = Number(process.env.CHROME_CDP_PORT || 9222);
 const CDP_BASE = `http://127.0.0.1:${CDP_PORT}`;
 const CHROME_APP = 'Google Chrome';
 const READY_TIMEOUT_MS = 20_000;
-
-const exec = (bin, args) =>
-  new Promise((resolve) => execFile(bin, args, { timeout: 15_000 }, (err, stdout) => resolve(err ? null : stdout)));
 
 async function probe() {
   try {
@@ -18,11 +15,34 @@ async function probe() {
   }
 }
 
-// `quit app` is AppleScript's graceful quit: Chrome writes its session out, so --restore-last-session brings every tab back. A kill would lose them.
-const isRunning = async () => (await exec('pgrep', ['-x', CHROME_APP])) !== null;
-const quitChrome = () => exec('osascript', ['-e', `quit app "${CHROME_APP}"`]);
-const launchChrome = () =>
-  exec('open', ['-a', CHROME_APP, '--args', `--remote-debugging-port=${CDP_PORT}`, '--restore-last-session']);
+// macOS: AppleScript quit so Chrome writes its session out, then --restore-last-session. Windows: taskkill without /F first.
+async function isRunning() {
+  if (IS_MAC) return (await execCapture('pgrep', ['-x', CHROME_APP])) !== null;
+  if (IS_WIN) {
+    const out = await execCapture('tasklist', ['/FI', 'IMAGENAME eq chrome.exe', '/NH']);
+    return !!(out && /chrome\.exe/i.test(out));
+  }
+  return (await execCapture('pgrep', ['-f', 'chrome|chromium'])) !== null;
+}
+
+async function quitChrome() {
+  if (IS_MAC) return execCapture('osascript', ['-e', `quit app "${CHROME_APP}"`]);
+  if (IS_WIN) {
+    await execCapture('taskkill', ['/IM', 'chrome.exe']);
+    return null;
+  }
+  return execCapture('pkill', ['-f', 'chrome|chromium']);
+}
+
+async function launchChrome() {
+  const args = [`--remote-debugging-port=${CDP_PORT}`, '--restore-last-session'];
+  if (IS_MAC) {
+    return execCapture('open', ['-a', CHROME_APP, '--args', ...args]);
+  }
+  const bin = process.env.CHROME_PATH || findChrome();
+  if (!bin) throw new Error('Google Chrome not found — install it or set CHROME_PATH');
+  return execCapture(bin, args);
+}
 
 async function waitUntil(check, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
@@ -36,7 +56,7 @@ async function waitUntil(check, timeoutMs) {
 
 async function waitReady() {
   if (await waitUntil(probe, READY_TIMEOUT_MS)) return;
-  throw new Error(`Chrome didn't open debug port ${CDP_PORT} within ${READY_TIMEOUT_MS / 1000}s — try opening it manually: open -a "${CHROME_APP}" --args --remote-debugging-port=${CDP_PORT}`);
+  throw new Error(`Chrome didn't open debug port ${CDP_PORT} within ${READY_TIMEOUT_MS / 1000}s — try opening Chrome with --remote-debugging-port=${CDP_PORT}`);
 }
 
 // Never quits anything. `needsRestart` hands the decision back to the user instead of taking it.

--- a/scripts/config-page.js
+++ b/scripts/config-page.js
@@ -80,6 +80,8 @@ h1 { font-size: 20px; margin: 0 0 4px; }
 p.sub { color: var(--muted); margin: 0 0 20px; font-size: 13px; line-height: 1.6; }
 section { background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 16px; margin-bottom: 14px; }
 h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); margin: 0 0 12px; }
+h3.subh { font-size: 13px; margin: 16px 0 8px; color: var(--fg); font-weight: 600; }
+h3.subh:first-of-type { margin-top: 4px; }
 .hint { color: var(--muted); font-size: 12.5px; line-height: 1.7; margin: 0 0 10px; }
 .row { display: grid; grid-template-columns: 130px 1fr auto; gap: 10px; align-items: center; margin-bottom: 8px; }
 .row label { color: var(--muted); font-size: 13px; }
@@ -139,8 +141,8 @@ footer { border-top: 1px solid var(--line); margin-top: 24px; padding: 24px 0 28
 <h1>${esc(MCP_NAME)}</h1>
 <p class="sub">Local panel (127.0.0.1) — never goes through Funnel, never reaches the internet.<br>Running repo: <span class="mono">${esc(repoRoot)}</span> · Your config &amp; keys: <span class="mono">${esc(userDir)}</span></p>
 
-<section><h2>1 · Tailscale — how claude.ai reaches this machine</h2>
-<p class="hint">claude.ai needs an address to call your machine. Two steps below, one time only.</p>
+<section><h2>1 · Tailscale — how clients reach this machine</h2>
+<p class="hint">Claude.ai and ChatGPT need an address to call your machine. Two steps below, one time only.</p>
 <ol class="steps">
   <li><span class="dot" id="tsInstalled">…</span> <a href="${TAILSCALE_DOWNLOAD_URL}" target="_blank" rel="noopener">Install Tailscale</a> and sign in.</li>
   <li><span class="dot" id="tsFunnel">…</span> Enable <a href="${TAILSCALE_FUNNEL_URL}" target="_blank" rel="noopener">Funnel</a> for your tailnet — free on every plan. <code>npm start</code> enables it automatically; it only prints a link for you to approve once, when the tailnet hasn't allowed it yet.</li>
@@ -148,7 +150,10 @@ footer { border-top: 1px solid var(--line); margin-top: 24px; padding: 24px 0 28
 <div class="acts"><button data-act="tailscale">Recheck</button><span class="msg" id="msgTs"></span></div>
 </section>
 
-<section id="connector"><h2>2 · Connector — paste into claude.ai</h2>
+<section id="connector"><h2>2 · Connectors — Claude + ChatGPT</h2>
+<p class="hint">Same Funnel URL for both. Folders / shell allowlist apply to whoever connects.</p>
+
+<h3 class="subh">Claude.ai</h3>
 <p class="lnk"><a href="${CONNECTOR_URL}" target="_blank" rel="noopener">↗ Open Add custom connector</a></p>
 ${field('MCP Name', MCP_NAME, false)}
 ${field('MCP URL', url)}
@@ -156,10 +161,18 @@ ${field('OAuth Client ID', client.clientId)}
 ${field('OAuth Client Secret', client.clientSecret)}
 ${field('Passphrase', passphrase)}
 <div class="acts"><button class="primary" data-act="copyAll">Copy all 5 values</button><span class="msg" id="msgConn"></span></div>
+
+<h3 class="subh">ChatGPT (Plus / Pro — Developer mode)</h3>
+<ol class="steps">
+  <li>ChatGPT → Settings → Apps &amp; Connectors (or Security) → turn on <strong>Developer mode</strong>.</li>
+  <li>Create a custom connector / app → paste <strong>MCP URL</strong> above (<code>…/mcp</code>). Auth: <strong>OAuth</strong> (ChatGPT registers itself — no Client ID/Secret paste).</li>
+  <li>When the browser opens the confirm page, enter the same <strong>Passphrase</strong>.</li>
+</ol>
+<p class="hint">Needs a paid ChatGPT plan with custom connectors. Write tools may be limited on Plus/Pro depending on OpenAI’s current policy.</p>
 </section>
 
-<section><h2>3 · Folders Claude is allowed to reach</h2>
-<p class="hint">Anything outside this list is fully off-limits to Claude.</p>
+<section><h2>3 · Folders the connector may reach</h2>
+<p class="hint">Anything outside this list is fully off-limits (Claude and ChatGPT share this list).</p>
 <div class="pathlist" id="paths"></div>
 <div class="acts">
   <button class="primary" data-act="pickFolder">+ Choose folder…</button>

--- a/scripts/gatekeeper.js
+++ b/scripts/gatekeeper.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// Public entry: minimal OAuth AS (DCR skipped) + reverse-proxy to mcp-hub — rationale: docs/ref/security-model.md
+// Public entry: OAuth AS (Claude pre-registered + ChatGPT DCR) + reverse-proxy to mcp-hub
 import http from 'node:http';
-import { loadOrCreateClient, loadOrCreatePassphrase, metadataHandlers, handleAuthorize, handleToken, verifyBearer } from './oauth.js';
+import { loadOrCreatePassphrase, metadataHandlers, handleAuthorize, handleToken, handleRegister, verifyBearer } from './oauth.js';
 import { handleStreamableMcp, terminateSession } from './streamable-bridge.js';
 import { readFile } from 'node:fs/promises';
 import { extname, join, normalize, sep } from 'node:path';
@@ -15,7 +15,6 @@ if (!ORIGIN) {
   process.exit(1);
 }
 
-const client = loadOrCreateClient();
 const passphrase = loadOrCreatePassphrase();
 const meta = metadataHandlers(ORIGIN);
 
@@ -72,8 +71,9 @@ const server = http.createServer(async (req, res) => {
 
   if ((path === '/.well-known/oauth-protected-resource' || path === '/.well-known/oauth-protected-resource/mcp') && req.method === 'GET') return meta.protectedResource(req, res);
   if ((path === '/.well-known/oauth-authorization-server' || path === '/.well-known/oauth-authorization-server/mcp') && req.method === 'GET') return meta.authorizationServer(req, res);
-  if (path === '/authorize' && (req.method === 'GET' || req.method === 'POST')) return handleAuthorize(req, res, client, passphrase, ORIGIN);
-  if (path === '/token' && req.method === 'POST') return handleToken(req, res, client);
+  if (path === '/register' && req.method === 'POST') return handleRegister(req, res);
+  if (path === '/authorize' && (req.method === 'GET' || req.method === 'POST')) return handleAuthorize(req, res, passphrase, ORIGIN);
+  if (path === '/token' && req.method === 'POST') return handleToken(req, res);
 
   if (path === '/mcp' || path === '/messages') {
     if (!verifyBearer(req.headers.authorization)) {

--- a/scripts/oauth.js
+++ b/scripts/oauth.js
@@ -1,10 +1,19 @@
 #!/usr/bin/env node
-// Minimal OAuth 2.1 authorization server, DCR skipped via pre-registered client — rationale: docs/ref/security-model.md
+// Minimal OAuth 2.1 authorization server.
+// Claude: pre-registered confidential client (paste Client ID/Secret), or DCR if it self-registers.
+// ChatGPT: RFC 7591 DCR + public client (token_endpoint_auth_method: none) + chatgpt.com redirect URIs.
 import { randomBytes, createHash, timingSafeEqual } from 'node:crypto';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { CLIENT_PATH as CLIENT_FILE, PASSPHRASE_PATH as PASSPHRASE_FILE, TOKENS_PATH as TOKENS_FILE } from './userdata.js';
+import {
+  CLIENT_PATH as CLIENT_FILE,
+  DCR_CLIENTS_PATH as DCR_FILE,
+  PASSPHRASE_PATH as PASSPHRASE_FILE,
+  TOKENS_PATH as TOKENS_FILE,
+} from './userdata.js';
 
-const CALLBACK_URI = 'https://claude.ai/api/mcp/auth_callback';
+const CLAUDE_CALLBACK = 'https://claude.ai/api/mcp/auth_callback';
+const CHATGPT_LEGACY_CALLBACK = 'https://chatgpt.com/connector_platform_oauth_redirect';
+const CHATGPT_CALLBACK_PREFIX = 'https://chatgpt.com/connector/oauth/';
 const CODE_TTL_MS = 5 * 60 * 1000;
 const ACCESS_TTL_S = 365 * 24 * 3600;
 // no 0/o/1/l/i — avoid visual ambiguity when typing; 32 chars = power of 2, unbiased byte%32
@@ -14,6 +23,12 @@ const PASSPHRASE_LENGTH = 10; // 32^10 = 2^50 — brute-force still infeasible o
 const authCodes = new Map();
 const accessTokens = new Map();
 const refreshTokens = new Map();
+
+function isAllowedRedirect(uri) {
+  if (typeof uri !== 'string' || !uri) return false;
+  if (uri === CLAUDE_CALLBACK || uri === CHATGPT_LEGACY_CALLBACK) return true;
+  return uri.startsWith(CHATGPT_CALLBACK_PREFIX);
+}
 
 // Tokens survive restarts: the connector is a long-lived file-access grant, and losing it on every
 // `npm start` forces a full re-authorize (passphrase) instead of the silent refresh the flow supports.
@@ -44,6 +59,36 @@ export function loadOrCreateClient() {
   return creds;
 }
 
+function loadDcrClients() {
+  if (!existsSync(DCR_FILE)) return {};
+  try {
+    return JSON.parse(readFileSync(DCR_FILE, 'utf8'));
+  } catch (e) {
+    console.error(`[oauth] ignoring malformed ${DCR_FILE}: ${e.message}`);
+    return {};
+  }
+}
+
+function saveDcrClients(map) {
+  writeFileSync(DCR_FILE, JSON.stringify(map, null, 2), { mode: 0o600 });
+}
+
+/** Static Claude client + any clients ChatGPT (or Claude) registered via /register. */
+export function resolveClient(clientId) {
+  if (!clientId) return null;
+  const staticClient = loadOrCreateClient();
+  if (clientId === staticClient.clientId) {
+    return {
+      clientId: staticClient.clientId,
+      clientSecret: staticClient.clientSecret,
+      redirectUris: [CLAUDE_CALLBACK],
+      tokenEndpointAuthMethod: 'client_secret_post',
+    };
+  }
+  const dcr = loadDcrClients()[clientId];
+  return dcr || null;
+}
+
 export function loadOrCreatePassphrase() {
   if (existsSync(PASSPHRASE_FILE)) return readFileSync(PASSPHRASE_FILE, 'utf8').trim();
   const bytes = randomBytes(PASSPHRASE_LENGTH);
@@ -68,7 +113,7 @@ function readBody(req) {
 }
 
 function json(res, status, body) {
-  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.writeHead(status, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
   res.end(JSON.stringify(body));
 }
 
@@ -82,8 +127,9 @@ export function metadataHandlers(origin) {
         issuer: origin,
         authorization_endpoint: `${origin}/authorize`,
         token_endpoint: `${origin}/token`,
+        registration_endpoint: `${origin}/register`,
         code_challenge_methods_supported: ['S256'],
-        token_endpoint_auth_methods_supported: ['client_secret_post'],
+        token_endpoint_auth_methods_supported: ['none', 'client_secret_post'],
         response_types_supported: ['code'],
         grant_types_supported: ['authorization_code', 'refresh_token'],
         authorization_response_iss_parameter_supported: true,
@@ -92,7 +138,49 @@ export function metadataHandlers(origin) {
   };
 }
 
-export async function handleAuthorize(req, res, client, passphrase, origin) {
+// RFC 7591 — ChatGPT calls this once per connector instance. Only Claude/ChatGPT redirect URIs are accepted.
+export async function handleRegister(req, res) {
+  let body;
+  try {
+    body = JSON.parse(await readBody(req) || '{}');
+  } catch {
+    return json(res, 400, { error: 'invalid_client_metadata' });
+  }
+  const redirectUris = body.redirect_uris;
+  if (!Array.isArray(redirectUris) || !redirectUris.length || !redirectUris.every(isAllowedRedirect)) {
+    return json(res, 400, { error: 'invalid_redirect_uri' });
+  }
+  const authMethod = body.token_endpoint_auth_method || 'none';
+  if (authMethod !== 'none' && authMethod !== 'client_secret_post') {
+    return json(res, 400, { error: 'invalid_client_metadata' });
+  }
+
+  const clientId = randomBytes(16).toString('hex');
+  const clientSecret = authMethod === 'client_secret_post' ? randomBytes(32).toString('hex') : null;
+  const entry = {
+    clientId,
+    clientSecret,
+    redirectUris,
+    tokenEndpointAuthMethod: authMethod,
+    clientName: typeof body.client_name === 'string' ? body.client_name : 'MCP client',
+  };
+  const map = loadDcrClients();
+  map[clientId] = entry;
+  saveDcrClients(map);
+
+  const resp = {
+    client_id: clientId,
+    client_name: entry.clientName,
+    redirect_uris: redirectUris,
+    token_endpoint_auth_method: authMethod,
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+  };
+  if (clientSecret) resp.client_secret = clientSecret;
+  return json(res, 201, resp);
+}
+
+export async function handleAuthorize(req, res, passphrase, origin) {
   res.setHeader('Cache-Control', 'no-store');
   const url = new URL(req.url, 'http://internal');
   const q = req.method === 'GET' ? url.searchParams : new URLSearchParams(await readBody(req));
@@ -101,8 +189,9 @@ export async function handleAuthorize(req, res, client, passphrase, origin) {
   const codeChallenge = q.get('code_challenge');
   const codeChallengeMethod = q.get('code_challenge_method');
   const state = q.get('state') || '';
+  const client = resolveClient(clientId);
 
-  if (clientId !== client.clientId || redirectUri !== CALLBACK_URI || codeChallengeMethod !== 'S256' || !codeChallenge) {
+  if (!client || !client.redirectUris.includes(redirectUri) || codeChallengeMethod !== 'S256' || !codeChallenge) {
     res.writeHead(400, { 'Content-Type': 'text/plain' });
     res.end('invalid authorize request');
     return;
@@ -154,20 +243,27 @@ button[disabled] { opacity: .6; cursor: progress; }
   res.end();
 }
 
-export async function handleToken(req, res, client) {
+function authenticateClient(body) {
+  const client = resolveClient(body.get('client_id'));
+  if (!client) return null;
+  if (client.tokenEndpointAuthMethod === 'none') return client;
+  if (!safeEqual(body.get('client_secret'), client.clientSecret || '')) return null;
+  return client;
+}
+
+export async function handleToken(req, res) {
   res.setHeader('Cache-Control', 'no-store');
   const body = new URLSearchParams(await readBody(req));
   const grantType = body.get('grant_type');
-
-  if (!safeEqual(body.get('client_id'), client.clientId) || !safeEqual(body.get('client_secret'), client.clientSecret)) {
-    return json(res, 401, { error: 'invalid_client' });
-  }
+  const client = authenticateClient(body);
+  if (!client) return json(res, 401, { error: 'invalid_client' });
 
   if (grantType === 'authorization_code') {
     const code = body.get('code');
     const entry = authCodes.get(code);
     if (!entry || entry.expires < Date.now()) return json(res, 400, { error: 'invalid_grant' });
     authCodes.delete(code);
+    if (entry.clientId !== client.clientId) return json(res, 400, { error: 'invalid_grant' });
     if (entry.redirectUri !== body.get('redirect_uri')) return json(res, 400, { error: 'invalid_grant' });
     const computed = createHash('sha256').update(body.get('code_verifier') || '').digest('base64url');
     if (computed !== entry.codeChallenge) return json(res, 400, { error: 'invalid_grant' });
@@ -176,7 +272,7 @@ export async function handleToken(req, res, client) {
 
   if (grantType === 'refresh_token') {
     const entry = refreshTokens.get(body.get('refresh_token'));
-    if (!entry) return json(res, 400, { error: 'invalid_grant' });
+    if (!entry || entry.clientId !== client.clientId) return json(res, 400, { error: 'invalid_grant' });
     return issueTokens(res, entry.clientId, body.get('refresh_token'));
   }
 

--- a/scripts/panel.js
+++ b/scripts/panel.js
@@ -10,6 +10,7 @@ import { listTabs, evaluate, connectChrome, restartChrome } from './chrome.js';
 import { loadAllowlist, readSettings } from './allowlist.js';
 import { funnelStatus } from './tailscale.js';
 import { HUB_CONFIG_PATH as HUB_CONFIG, SETTINGS_PATH, USER_DIR } from './userdata.js';
+import { IS_MAC, IS_WIN } from './platform.js';
 
 const REPO_ROOT = process.cwd();
 const PUBLIC_DIR = path.join(REPO_ROOT, 'public');
@@ -23,31 +24,52 @@ const MIME = { '.ico': 'image/x-icon', '.png': 'image/png', '.svg': 'image/svg+x
 const readJson = (file, fallback) => (existsSync(file) ? JSON.parse(readFileSync(file, 'utf8')) : fallback);
 
 // Shows placeholders expanded and saves back what it shows: a folder list is only checkable if it reads as real folders.
-const expandPath = (p, dataDir) => p.replace(/\$\{MCP_DATA_DIR\}/g, dataDir).replace(/\$\{HOME\}/g, os.homedir());
+const expandPath = (p, dataDir) =>
+  p
+    .replace(/\$\{MCP_DATA_DIR\}/g, dataDir)
+    .replace(/\$\{HOME\}/g, os.homedir())
+    .replace(/\$\{userHome\}/g, os.homedir())
+    .replace(/\$\{pathSeparator\}/g, path.sep)
+    .replace(/\$\{\/\}/g, path.sep);
 
 function filesystemPaths(dataDir) {
   return readJson(HUB_CONFIG, {}).mcpServers.filesystem.args.slice(2).map((p) => expandPath(p, dataDir));
 }
 
-// `choose folder` is macOS's own picker: no path typing, no copy-paste, and multi-select in one pass.
+// Native folder picker: macOS multi-select via AppleScript; Windows single-select via FolderBrowserDialog.
 // Cancelling is a normal outcome, not a failure — it comes back as an empty list.
 async function pickFolders() {
-  const script = [
-    'activate',
-    'set picked to choose folder with prompt "Choose folders Claude may access" with multiple selections allowed',
-    'set out to ""',
-    'repeat with f in picked',
-    'set out to out & POSIX path of f & linefeed',
-    'end repeat',
-    'return out',
-  ].flatMap((line) => ['-e', line]);
-  try {
-    const out = await run('osascript', script);
-    return out.split('\n').map((s) => s.replace(/\/$/, '')).filter(Boolean);
-  } catch (e) {
-    if (/User canceled|-128/.test(e.message)) return [];
-    throw e;
+  if (IS_MAC) {
+    const script = [
+      'activate',
+      'set picked to choose folder with prompt "Choose folders Claude may access" with multiple selections allowed',
+      'set out to ""',
+      'repeat with f in picked',
+      'set out to out & POSIX path of f & linefeed',
+      'end repeat',
+      'return out',
+    ].flatMap((line) => ['-e', line]);
+    try {
+      const out = await run('osascript', script);
+      return out.split('\n').map((s) => s.replace(/\/$/, '')).filter(Boolean);
+    } catch (e) {
+      if (/User canceled|-128/.test(e.message)) return [];
+      throw e;
+    }
   }
+  if (IS_WIN) {
+    const ps = [
+      'Add-Type -AssemblyName System.Windows.Forms',
+      '$d = New-Object System.Windows.Forms.FolderBrowserDialog',
+      '$d.Description = "Choose a folder Claude may access"',
+      '$d.ShowNewFolderButton = $false',
+      'if ($d.ShowDialog() -ne [System.Windows.Forms.DialogResult]::OK) { exit 0 }',
+      '[Console]::Out.Write($d.SelectedPath)',
+    ].join('; ');
+    const out = (await run('powershell.exe', ['-NoProfile', '-STA', '-Command', ps])).trim();
+    return out ? [out] : [];
+  }
+  throw new Error('folder picker is not supported on this OS — paste absolute paths into the list');
 }
 
 // search/shell enforce path containment via the same list, so it never drifts from what this panel shows as "allowed".
@@ -72,10 +94,10 @@ function validateAllowlist(allowlist) {
 }
 
 function validatePaths(paths) {
-  if (!Array.isArray(paths) || !paths.every((p) => typeof p === 'string' && p.startsWith('/'))) {
+  if (!Array.isArray(paths) || !paths.every((p) => typeof p === 'string' && path.isAbsolute(p))) {
     throw new Error('folder list must be absolute paths');
   }
-  return paths;
+  return paths.map((p) => path.normalize(p));
 }
 
 function setShellAllowlist(allowlist) {
@@ -86,7 +108,7 @@ function setShellAllowlist(allowlist) {
 
 function run(command, args, cwd) {
   return new Promise((resolve, reject) => {
-    execFile(command, args, { cwd, timeout: 180_000, maxBuffer: 1024 * 1024 }, (err, stdout, stderr) =>
+    execFile(command, args, { cwd, timeout: 180_000, maxBuffer: 1024 * 1024, windowsHide: true }, (err, stdout, stderr) =>
       err ? reject(new Error(stderr || err.message)) : resolve(stdout || stderr || '(no output)'),
     );
   });
@@ -106,8 +128,16 @@ async function installRules() {
     }
     repo = RULES_CLONE_DIR;
   }
-  const log = await run('bash', [path.join(repo, 'install.sh')], repo);
-  return `${log.trim().split('\n').pop()} (source: ${repo})`;
+  const bash = IS_WIN ? 'bash.exe' : 'bash';
+  try {
+    const log = await run(bash, [path.join(repo, 'install.sh')], repo);
+    return `${log.trim().split('\n').pop()} (source: ${repo})`;
+  } catch (e) {
+    if (IS_WIN && /ENOENT|not found|not recognized/i.test(e.message)) {
+      throw new Error('bash not found — install Git for Windows (includes bash) or run the install command from the panel manually');
+    }
+    throw e;
+  }
 }
 
 const readBody = (req) =>

--- a/scripts/platform.js
+++ b/scripts/platform.js
@@ -1,0 +1,67 @@
+// Tiny OS differences so the rest of the code can stay free of `win32` checks.
+import { execFile, execFileSync, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+export const IS_WIN = process.platform === 'win32';
+export const IS_MAC = process.platform === 'darwin';
+
+const require = createRequire(import.meta.url);
+
+/** mcp-hub's CLI entry — spawn via node so Windows never has to resolve `npx.cmd`. */
+export function hubCliPath() {
+  return require.resolve('mcp-hub/dist/cli.js');
+}
+
+/** Env every child of `npm start` should inherit — ensures `${HOME}` placeholders in mcp-hub config resolve on Windows. */
+export function childEnv(extra = {}) {
+  const home = process.env.HOME || os.homedir();
+  return {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: process.env.USERPROFILE || home,
+    ...extra,
+  };
+}
+
+export function spawnNode(scriptOrArgs, opts = {}) {
+  const args = Array.isArray(scriptOrArgs) ? scriptOrArgs : [scriptOrArgs];
+  return spawn(process.execPath, args, { stdio: 'inherit', windowsHide: true, ...opts });
+}
+
+export function openUrl(url) {
+  if (IS_MAC) execFileSync('open', [url]);
+  else if (IS_WIN) execFileSync('cmd', ['/c', 'start', '', url], { windowsHide: true });
+  else execFileSync('xdg-open', [url]);
+}
+
+export function findChrome() {
+  if (IS_MAC) return null; // launched via `open -a`
+  if (IS_WIN) {
+    const candidates = [
+      path.join(process.env.PROGRAMFILES || '', 'Google', 'Chrome', 'Application', 'chrome.exe'),
+      path.join(process.env['PROGRAMFILES(X86)'] || '', 'Google', 'Chrome', 'Application', 'chrome.exe'),
+      path.join(process.env.LOCALAPPDATA || '', 'Google', 'Chrome', 'Application', 'chrome.exe'),
+    ];
+    return candidates.find((p) => p && existsSync(p)) || null;
+  }
+  for (const bin of ['google-chrome', 'google-chrome-stable', 'chromium', 'chromium-browser']) {
+    try {
+      execFileSync('which', [bin], { stdio: 'ignore' });
+      return bin;
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+
+export function execCapture(bin, args, opts = {}) {
+  return new Promise((resolve) => {
+    execFile(bin, args, { timeout: 15_000, windowsHide: true, ...opts }, (err, stdout) =>
+      resolve(err ? null : stdout),
+    );
+  });
+}

--- a/scripts/roots.js
+++ b/scripts/roots.js
@@ -12,10 +12,20 @@ const parsed = (process.env.MCP_DATA_DIR || os.homedir())
 export const ROOTS = parsed.length ? parsed : [path.resolve(os.homedir())];
 export const ROOT = ROOTS[0];
 
+function containedIn(abs, root) {
+  // Windows paths are case-insensitive; drive letter casing from different APIs must not bypass the boundary.
+  if (process.platform === 'win32') {
+    const a = abs.toLowerCase();
+    const r = root.toLowerCase();
+    return a === r || a.startsWith(r + path.sep.toLowerCase());
+  }
+  return abs === root || abs.startsWith(root + path.sep);
+}
+
 export function resolveUnderRoot(target) {
   if (!target) return ROOT;
   const abs = path.isAbsolute(target) ? path.resolve(target) : path.resolve(ROOT, target);
-  const allowed = ROOTS.some((root) => abs === root || abs.startsWith(root + path.sep));
+  const allowed = ROOTS.some((root) => containedIn(abs, root));
   if (!allowed) {
     throw new Error(`path is outside the allowed roots: ${ROOTS.join(', ')}`);
   }

--- a/scripts/search-mcp.js
+++ b/scripts/search-mcp.js
@@ -3,7 +3,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { execFile } from 'node:child_process';
-import { opendirSync } from 'node:fs';
+import { opendirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { z } from 'zod';
 import { ROOT, resolveUnderRoot } from './roots.js';
@@ -63,13 +63,51 @@ function findPath(query, from, limit) {
   return `${found.length} result(s) under ${base}:\n${head.join('\n')}${note}`;
 }
 
+function nameMatchesGlob(name, glob) {
+  if (!glob) return true;
+  const source = `^${glob.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.')}$`;
+  return new RegExp(source, 'i').test(name);
+}
+
+// Pure-JS fallback when system grep isn't available (typical on Windows without Git usr\bin).
+function searchContentNode(query, base, glob, limit) {
+  const needle = query.toLowerCase();
+  const found = [];
+  walk(base, (full, isDir) => {
+    if (isDir || found.length >= limit * 4) return;
+    if (!nameMatchesGlob(path.basename(full), glob)) return;
+    let text;
+    try {
+      text = readFileSync(full, 'utf8');
+    } catch {
+      return;
+    }
+    if (text.includes('\0')) return;
+    const lines = text.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].toLowerCase().includes(needle)) {
+        found.push(`${full}:${i + 1}:${lines[i]}`);
+        if (found.length >= limit * 4) break;
+      }
+    }
+  });
+  if (!found.length) return `no lines matched "${query}" under ${base}`;
+  const head = found.slice(0, limit);
+  const note = found.length > head.length ? `\n… ${found.length - head.length} more line(s)` : '';
+  return `${found.length} matching line(s):\n${head.join('\n')}${note}`;
+}
+
 function searchContent(query, from, glob, limit) {
   const base = resolveUnderRoot(from);
+  if (process.platform === 'win32') {
+    return Promise.resolve(searchContentNode(query, base, glob, limit));
+  }
   const args = ['-rnI', '--binary-files=without-match', ...[...SKIP_DIRS].map((d) => `--exclude-dir=${d}`)];
   if (glob) args.push(`--include=${glob}`);
   args.push('-e', query, base);
   return new Promise((resolve) => {
     execFile('grep', args, { timeout: 30_000, maxBuffer: 4 * 1024 * 1024 }, (err, stdout, stderr) => {
+      if (err && err.code === 'ENOENT') return resolve(searchContentNode(query, base, glob, limit));
       const lines = (stdout || '').split('\n').filter(Boolean);
       if (!lines.length) return resolve(err && stderr ? `error: ${stderr.trim()}` : `no lines matched "${query}" under ${base}`);
       const head = lines.slice(0, limit);

--- a/scripts/shell-mcp.js
+++ b/scripts/shell-mcp.js
@@ -8,7 +8,8 @@ import { loadAllowlist } from './allowlist.js';
 import { ROOT, ROOTS, resolveUnderRoot } from './roots.js';
 
 class Shell {
-  static DANGEROUS_CHARS = /[;&|`$<>\n\\]/;
+  // Backslash is escape/chaining on Unix but the normal path separator on Windows — only treat it as dangerous off-Windows.
+  static DANGEROUS_CHARS = process.platform === 'win32' ? /[;&|`$<>\n]/ : /[;&|`$<>\n\\]/;
 
   // Quotes group an argument and are then stripped, as a shell would. Splitting on whitespace alone left them in the argv, so `find -name "*.ts"` silently searched for a name containing quote marks.
   static tokenize(command) {
@@ -62,7 +63,7 @@ class Shell {
 
   run(bin, args, cwd) {
     return new Promise((resolve) => {
-      execFile(bin, args, { cwd, timeout: 10_000, maxBuffer: 1024 * 1024 }, (err, stdout, stderr) => {
+      execFile(bin, args, { cwd, timeout: 10_000, maxBuffer: 1024 * 1024, windowsHide: true }, (err, stdout, stderr) => {
         if (err) {
           resolve({ content: [{ type: 'text', text: stderr || err.message }], isError: true });
         } else {

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,18 +1,19 @@
 #!/usr/bin/env node
 // Orchestrates mcp-hub + gatekeeper behind 1 `npm start`; foreground by design, manual stop/start only
-import { spawn, execFileSync } from 'node:child_process';
 import { funnelStatus, enableFunnel } from './tailscale.js';
 import { randomBytes } from 'node:crypto';
 import os from 'node:os';
 import { loadOrCreateClient, loadOrCreatePassphrase } from './oauth.js';
 import { startPanel } from './panel.js';
 import { HUB_CONFIG_PATH, USER_DIR } from './userdata.js';
+import { childEnv, hubCliPath, openUrl, spawnNode } from './platform.js';
 
 const dataDir = process.env.MCP_DATA_DIR || os.homedir();
 const hubPort = process.env.MCP_HUB_PORT || '19999';
 const gatePort = process.env.GATEKEEPER_PORT || '9999';
 const panelPort = process.env.PANEL_PORT || '9998';
 const panelToken = randomBytes(16).toString('hex');
+const env = childEnv({ MCP_DATA_DIR: dataDir });
 
 console.log(`[start] config & keys: ${USER_DIR}`);
 
@@ -43,12 +44,12 @@ let hub;
 let shuttingDown = false;
 
 function spawnHub() {
-  const child = spawn('npx', ['mcp-hub', '--port', hubPort, '--config', HUB_CONFIG_PATH], {
-    stdio: 'inherit',
-    env: { ...process.env, MCP_DATA_DIR: dataDir },
+  const child = spawnNode([hubCliPath(), '--port', hubPort, '--config', HUB_CONFIG_PATH], {
+    env: { ...env, MCP_DATA_DIR: dataDir },
   });
   // Only an unexpected death tears the stack down; a restart detaches the old child first.
   child.on('exit', () => child === hub && shutdown());
+  child.on('error', (e) => console.error(`[start] mcp-hub failed to start: ${e.message}`));
   hub = child;
 }
 
@@ -60,15 +61,15 @@ function restartHub() {
 }
 
 spawnHub();
-const gate = spawn('node', ['./scripts/gatekeeper.js'], {
-  stdio: 'inherit',
-  env: { ...process.env, MCP_HUB_PORT: hubPort, GATEKEEPER_PORT: gatePort, PUBLIC_ORIGIN: origin || '' },
+const gate = spawnNode(['./scripts/gatekeeper.js'], {
+  env: { ...env, MCP_HUB_PORT: hubPort, GATEKEEPER_PORT: gatePort, PUBLIC_ORIGIN: origin || '' },
 });
+gate.on('error', (e) => console.error(`[start] gatekeeper failed to start: ${e.message}`));
 
 const panel = startPanel({ port: Number(panelPort), token: panelToken, origin, client, passphrase, dataDir, restartHub });
 const panelUrl = `http://127.0.0.1:${panelPort}/?t=${panelToken}`;
 try {
-  execFileSync('open', [panelUrl]);
+  openUrl(panelUrl);
 } catch (e) {
   console.error(`[start] could not auto-open the panel (open manually: ${panelUrl}): ${e.message}`);
 }

--- a/scripts/tailscale.js
+++ b/scripts/tailscale.js
@@ -5,7 +5,7 @@ import { execFile } from 'node:child_process';
 
 const run = (args) =>
   new Promise((resolve) =>
-    execFile('tailscale', args, { timeout: 8000 }, (err, stdout, stderr) =>
+    execFile('tailscale', args, { timeout: 8000, windowsHide: true }, (err, stdout, stderr) =>
       resolve({ ok: !err, out: err ? stderr || err.message : stdout }),
     ),
   );

--- a/scripts/userdata.js
+++ b/scripts/userdata.js
@@ -9,6 +9,7 @@ export const USER_DIR = path.join(os.homedir(), '.aki', 'mcpsv');
 export const SETTINGS_PATH = path.join(USER_DIR, 'setting.json');
 export const HUB_CONFIG_PATH = path.join(USER_DIR, 'mcp-hub.config.json');
 export const CLIENT_PATH = path.join(USER_DIR, 'oauth-client.json');
+export const DCR_CLIENTS_PATH = path.join(USER_DIR, 'oauth-dcr-clients.json');
 export const PASSPHRASE_PATH = path.join(USER_DIR, 'passphrase.txt');
 export const TOKENS_PATH = path.join(USER_DIR, 'tokens.json');
 


### PR DESCRIPTION
- Fixed issues on Windows: `npm start` now works with Unix-only syntax, and hub starts via `node` instead of `npx`.
- Enhanced Windows compatibility: folder picker uses WinForms, and shell allowlist now ignores backslashes as dangerous characters.
- Updated `mcp-hub.config.json` for cross-platform support, ensuring home-relative paths expand correctly on both macOS and Windows.
- Improved README to reflect support for both macOS and Windows, along with installation requirements.
- Added a new `platform.js` module to handle OS-specific functionality, streamlining the codebase.