### PR TITLE
feat(ingress): support FRP / custom reverse proxy via PUBLIC_ORIGIN

### DIFF
--- a/scripts/config-page.js
+++ b/scripts/config-page.js
@@ -78,7 +78,7 @@ function field(label, value, hl = false) {
   return `<div class="row"><label>${esc(label)}</label>${copyEl(value, hl)}</div>`;
 }
 
-export function renderPanel({ origin, client, passphrase, token, repoRoot, rulesDir, userDir, updateInfo = {}, hasGit = false }) {
+export function renderPanel({ origin, client, passphrase, token, repoRoot, rulesDir, userDir, updateInfo = {}, hasGit = false, ingressMode = 'tailscale' }) {
   const url = origin ? `${origin}/mcp` : 'not available yet, see section 0';
   const regUrl = origin ? `${origin}/register` : 'not available yet, see section 0';
   const mcpUpd = updateInfo.mcp || {};
@@ -225,10 +225,20 @@ ${updateBanner}
 </section>
 
 <section id="s0"><h2>0 · Setup <span class="done-tag">done</span></h2>
+${ingressMode === 'frp' ? `
+<p class="hint">FRP / custom reverse proxy is configured. The server listens on localhost:${esc(process.env.GATEKEEPER_PORT || '9999')}; your FRP routes external traffic to this port.</p>
+<ol class="steps">
+  <li><span class="dot ok">✓</span> FRP / custom ingress: ${copyEl(origin, true)}</li>
+  <li><span class="dot ok">✓</span> Clone / download the <span class="mono">aki-mcp-sv</span> repo.</li>
+  <li><span class="dot ok">✓</span> ${copyEl('npm install')}.</li>
+  <li><span class="dot ok">✓</span> ${copyEl('PUBLIC_ORIGIN="' + esc(origin) + '" npm start')} — running now.</li>
+</ol>
+${field('FRP config', 'Set PUBLIC_ORIGIN=' + esc(origin) + ' in your environment. Your FRP must forward :443 → localhost:' + esc(process.env.GATEKEEPER_PORT || '9999') + ' via TCP (no TLS termination on the proxy). TLS is handled by the gatekeeper itself — set MCP_TLS_CERT and MCP_TLS_KEY to your cert/key paths.')}
+` : `
 <p class="hint">One-time prerequisites. You're reading this panel, so the last three already ran; the two Tailscale checks below are live.</p>
 <ol class="steps">
-  <li><span class="dot" id="tsInstalled">…</span> <a href="${TAILSCALE_DOWNLOAD_URL}" target="_blank" rel="noopener">Install Tailscale</a> and sign in.</li>
-  <li><span class="dot" id="tsFunnel">…</span> Enable <a href="${TAILSCALE_FUNNEL_URL}" target="_blank" rel="noopener">Funnel</a> for your tailnet, free on every plan. ${copyEl('npm start')} enables it automatically; it only prints a link for you to approve once, when the tailnet hasn't allowed it yet.</li>
+  <li><span class="dot" id="tsInstalled">...</span> <a href="${TAILSCALE_DOWNLOAD_URL}" target="_blank" rel="noopener">Install Tailscale</a> and sign in.</li>
+  <li><span class="dot" id="tsFunnel">...</span> Enable <a href="${TAILSCALE_FUNNEL_URL}" target="_blank" rel="noopener">Funnel</a> for your tailnet, free on every plan. ${copyEl('npm start')} enables it automatically; it only prints a link for you to approve once, when the tailnet hasn't allowed it yet.</li>
   <li><span class="dot ok">✓</span> Clone / download the <span class="mono">aki-mcp-sv</span> repo.</li>
   <li><span class="dot ok">✓</span> ${copyEl('npm install')}.</li>
   <li><span class="dot ok">✓</span> ${copyEl('npm start')} — running now.</li>
@@ -236,10 +246,11 @@ ${updateBanner}
 <div class="acts"><button data-act="tailscale">Recheck</button><span class="msg" id="msgTs"></span></div>
 <p class="hint">Connector keeps dropping with <em>"hostname doesn't resolve / isn't reachable"</em>? The Funnel edge desynced — a Tailscale-side issue, not this server. Re-sync it in a terminal (needs ${copyEl('sudo')}, so it can't be a button here), then reconnect the connector. Why: <span class="mono">docs/research/claude-ai-oauth-connector.md</span> round 9.</p>
 ${field('Re-sync command', 'tailscale funnel --https=443 off && tailscale serve reset && tailscale funnel --bg 9999')}
+`}
 </section>
 
 <section id="s1"><h2>1 · Connectors: Claude, Grok, ChatGPT, Gemini</h2>
-<p class="hint">Same Funnel URL for every client. Folders / shell allowlist apply to whoever connects. Fill the three common values below, then open your client's tab.</p>
+<p class="hint">Same ${ingressMode === 'frp' ? 'public' : 'Funnel'} URL for every client. Folders / shell allowlist apply to whoever connects. Fill the three common values below, then open your client's tab.</p>
 ${field('MCP Name', MCP_NAME)}
 ${field('MCP URL', url, true)}
 ${field('Passphrase', passphrase)}
@@ -661,12 +672,13 @@ async function loadState() {
 }
 
 async function loadTailscale() {
+  const s = await api('GET', '/api/tailscale');
+  if (s.frp) return 'FRP / custom ingress: ' + (s.origin || 'not configured');
   const mark = (id, ok) => {
     const el = document.getElementById(id);
     el.textContent = ok ? '✓' : '✕';
     el.className = 'dot ' + (ok ? 'ok' : 'err');
   };
-  const s = await api('GET', '/api/tailscale');
   mark('tsInstalled', s.installed);
   mark('tsFunnel', s.funnel);
   if (!s.installed) return 'tailscale command not found on this machine';

--- a/scripts/gatekeeper.js
+++ b/scripts/gatekeeper.js
@@ -1,6 +1,8 @@
 // Public entry: OAuth AS (Claude pre-registered + ChatGPT DCR) + Streamable HTTP /mcp via streamable-bridge.
 // Runs in-process inside start.js (docs/plan/consolidate-mcp-tool-processes.md, Part B): startGatekeeper() returns the http.Server so the orchestrator can close it on shutdown.
 import http from 'node:http';
+import https from 'node:https';
+import { readFileSync } from 'node:fs';
 import { loadOrCreatePassphrase, metadataHandlers, handleAuthorize, handleToken, handleRegister, verifyBearer } from './oauth.js';
 import { handleStreamableMcp, terminateSession } from './streamable-bridge.js';
 import { log, logErr } from './log.js';
@@ -8,15 +10,28 @@ import { serveStatic } from './http.js';
 
 const STATIC_ALIASES = { '/favicon.ico': '/favicon/favicon.ico' };
 
-// origin: the public https origin (Tailscale MagicDNS). onFatal: called if the listen socket errors, so the orchestrator tears the whole stack down instead of leaking an orphaned hub.
-export function startGatekeeper(origin, onFatal) {
-  if (!origin) throw new Error('PUBLIC_ORIGIN (Tailscale origin) is not set');
+// origin: the public https origin. onFatal: called if the listen socket errors, so the orchestrator tears the whole stack down instead of leaking an orphaned hub.
+// tls: optional { cert, key } paths for running HTTPS directly (FRP / custom ingress without TLS termination at the proxy).
+export function startGatekeeper(origin, onFatal, tls) {
+  if (!origin) throw new Error('PUBLIC_ORIGIN is not set (set the env var or configure Tailscale Funnel)');
 
   const port = Number(process.env.GATEKEEPER_PORT || 9999);
   const passphrase = loadOrCreatePassphrase();
   const meta = metadataHandlers(origin);
 
-  const server = http.createServer(async (req, res) => {
+  let tlsOpts;
+  if (tls) {
+    try {
+      tlsOpts = { cert: readFileSync(tls.cert), key: readFileSync(tls.key) };
+    } catch (e) {
+      throw new Error(`TLS cert/key read failed: ${e.message}`);
+    }
+  }
+
+  const createServer = (reqListener) =>
+    tlsOpts ? https.createServer(tlsOpts, reqListener) : http.createServer(reqListener);
+
+  const server = createServer(async (req, res) => {
     const path = (req.url || '').split('?')[0];
     const t0 = Date.now();
     res.on('finish', () => log(`[gatekeeper] ${req.method} ${req.url} -> ${res.statusCode} ${Date.now() - t0}ms`));
@@ -68,7 +83,7 @@ export function startGatekeeper(origin, onFatal) {
     onFatal?.();
   });
   server.listen(port, () => {
-    log(`[gatekeeper] listening on :${port} (OAuth-protected /mcp)`);
+    log(`[gatekeeper] listening on :${port} (${tlsOpts ? 'HTTPS' : 'HTTP'}, OAuth-protected /mcp)`);
   });
 
   return server;

--- a/scripts/panel.js
+++ b/scripts/panel.js
@@ -152,14 +152,14 @@ function trustedDirStatus(dataDir) {
 }
 
 const ROUTES = {
-  'GET /api/state': async (body, ctx) => ({
+  'GET /api/state': async (_body, ctx) => ({
     paths: filesystemPaths(ctx.dataDir),
     // The same call the MCP server enforces with, so the textarea can never show a set that isn't the live one.
     allowlist: loadAllowlist(),
     trustedDirs: trustedDirStatus(ctx.dataDir),
     ruleFiles: existsSync(RULES_DIR) ? readdirSync(RULES_DIR).filter((f) => /^(index|RULE-.+|METHOD-.+)\.md$/.test(f)).sort() : [],
   }),
-  'GET /api/tailscale': async () => funnelStatus(process.env.GATEKEEPER_PORT || '9999'),
+  'GET /api/tailscale': async (_body, ctx) => ctx.ingressMode === 'frp' ? { frp: true, origin: ctx.origin } : funnelStatus(process.env.GATEKEEPER_PORT || '9999'),
   'POST /api/paths': async (body, ctx) => {
     setFilesystemPaths(validatePaths(body.paths));
     ctx.restartHub();
@@ -174,7 +174,7 @@ const ROUTES = {
     setTrustedDirs(validateTrustedDirs(body.dirs));
     return { ok: true, message: `saved trusted directories to ${SETTINGS_PATH}` };
   },
-  'POST /api/restart': async (body, ctx) => {
+  'POST /api/restart': async (_body, ctx) => {
     ctx.restartHub();
     return { ok: true, message: 'restarted mcp-hub' };
   },
@@ -182,7 +182,7 @@ const ROUTES = {
   'POST /api/pull-update': async () => ({ ok: true, message: await pullUpdate() }),
 };
 
-export function startPanel({ port, token, origin, client, passphrase, dataDir, restartHub, updateInfo }) {
+export function startPanel({ port, token, origin, client, passphrase, dataDir, restartHub, updateInfo, ingressMode = 'tailscale' }) {
   const server = http.createServer(async (req, res) => {
     const [urlPath, query] = (req.url || '').split('?');
     const route = `${req.method} ${urlPath}`;
@@ -193,7 +193,7 @@ export function startPanel({ port, token, origin, client, passphrase, dataDir, r
         return res.end('wrong token — open the URL that `npm start` printed');
       }
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-      return res.end(renderPanel({ origin, client, passphrase, token, repoRoot: REPO_ROOT, rulesDir: RULES_DIR, userDir: USER_DIR, updateInfo, hasGit: existsSync(path.join(REPO_ROOT, '.git')) }));
+      return res.end(renderPanel({ origin, client, passphrase, token, repoRoot: REPO_ROOT, rulesDir: RULES_DIR, userDir: USER_DIR, updateInfo, hasGit: existsSync(path.join(REPO_ROOT, '.git')), ingressMode }));
     }
 
     if (req.method === 'GET' && await serveStatic(res, urlPath)) return;
@@ -203,7 +203,7 @@ export function startPanel({ port, token, origin, client, passphrase, dataDir, r
     if (req.headers['x-panel-token'] !== token) return json(res, 403, { error: 'sai token' });
 
     try {
-      json(res, 200, await handler(JSON.parse((await readBody(req)) || '{}'), { restartHub, dataDir }));
+      json(res, 200, await handler(JSON.parse((await readBody(req)) || '{}'), { restartHub, dataDir, ingressMode, origin }));
     } catch (e) {
       json(res, 400, { error: e.message });
     }

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -28,22 +28,34 @@ console.log(`[start] config & keys: ${USER_DIR}`);
 const client = loadOrCreateClient();
 const passphrase = loadOrCreatePassphrase();
 
-let tailscale = await funnelStatus(gatePort);
-if (!tailscale.installed) {
-  console.error('[start] could not run `tailscale` — check it is installed and logged in: https://tailscale.com/download');
-} else {
-  if (!tailscale.running) {
-    const { ok, out } = await bringUp();
-    console[ok ? 'log' : 'error'](`[start] tailscale was stopped, starting it: ${ok ? 'done' : out.trim()}`);
-    tailscale = await funnelStatus(gatePort);
-  }
-  if (tailscale.running && !tailscale.funnel) {
-    const { ok, out } = await enableFunnel(gatePort);
-    console[ok ? 'log' : 'error'](`[start] enabling funnel ${gatePort}: ${ok ? 'done' : out.trim()}`);
-  }
-}
+const frpOrigin = process.env.PUBLIC_ORIGIN?.replace(/\/$/, '');
+let tailscale;
+let origin;
+let ingressMode = 'tailscale';
 
-const origin = tailscale.host ? `https://${tailscale.host}` : null;
+if (frpOrigin) {
+  // FRP / custom reverse proxy: skip Tailscale entirely, use the provided origin as-is
+  origin = frpOrigin;
+  ingressMode = 'frp';
+  tailscale = { installed: false, running: false, host: null, funnel: false, frp: true };
+  console.log(`[start] PUBLIC_ORIGIN is set — using FRP / custom ingress: ${origin}`);
+} else {
+  tailscale = await funnelStatus(gatePort);
+  if (!tailscale.installed) {
+    console.error('[start] could not run `tailscale` — check it is installed and logged in: https://tailscale.com/download');
+  } else {
+    if (!tailscale.running) {
+      const { ok, out } = await bringUp();
+      console[ok ? 'log' : 'error'](`[start] tailscale was stopped, starting it: ${ok ? 'done' : out.trim()}`);
+      tailscale = await funnelStatus(gatePort);
+    }
+    if (tailscale.running && !tailscale.funnel) {
+      const { ok, out } = await enableFunnel(gatePort);
+      console[ok ? 'log' : 'error'](`[start] enabling funnel ${gatePort}: ${ok ? 'done' : out.trim()}`);
+    }
+  }
+  origin = tailscale.host ? `https://${tailscale.host}` : null;
+}
 
 if (origin) {
   console.log(`[start] Remote MCP server URL: ${origin}/mcp`);
@@ -85,15 +97,18 @@ function restartHub() {
 
 spawnHub();
 // Gatekeeper runs in-process (docs/plan/consolidate-mcp-tool-processes.md, Part B); a fatal listen error tears the whole stack down via shutdown, so the hub is never left orphaned.
+const tls = process.env.MCP_TLS_CERT && process.env.MCP_TLS_KEY
+  ? { cert: process.env.MCP_TLS_CERT, key: process.env.MCP_TLS_KEY }
+  : null;
 let gateServer;
 try {
-  gateServer = startGatekeeper(origin, shutdown);
+  gateServer = startGatekeeper(origin, shutdown, tls);
 } catch (e) {
   console.error(`[start] gatekeeper failed to start: ${e.message}`);
   shutdown();
 }
 
-panel = startPanel({ port: Number(panelPort), token: panelToken, origin, client, passphrase, dataDir, restartHub, updateInfo });
+panel = startPanel({ port: Number(panelPort), token: panelToken, origin, client, passphrase, dataDir, restartHub, updateInfo, ingressMode });
 const panelUrl = `http://127.0.0.1:${panelPort}/?t=${panelToken}`;
 try {
   await openBrowser(panelUrl);


### PR DESCRIPTION
## Summary

支持通过 `PUBLIC_ORIGIN` 环境变量用 FRP 或其他自定义反向代理替代 Tailscale Funnel。Tailscale 仍是默认模式，无破坏性变更。

## Changes

| 文件 | 改动 |
|---|---|
| `scripts/start.js` | 检测 `PUBLIC_ORIGIN` 环境变量，设置后跳过所有 Tailscale 逻辑 |
| `scripts/gatekeeper.js` | 新增 `tls` 参数，支持 `MCP_TLS_CERT` + `MCP_TLS_KEY` 让 gatekeeper 直接提供 HTTPS（FRP 纯 TCP 隧道，不在代理端终止 TLS） |
| `scripts/panel.js` | `/api/tailscale` 路由在 FRP 模式下返回 `{ frp: true, origin }`；向 handler context 传入 `ingressMode` |
| `scripts/config-page.js` | FRP 模式下步骤 0 展示 FRP 配置提示（隐藏 Tailscale 检查 UI），步骤 1 提示文字自适应 |

## 新增环境变量

| 变量 | 作用 |
|---|---|
| `PUBLIC_ORIGIN` | 公网域名，设置后跳过 Tailscale |
| `MCP_TLS_CERT` | TLS 证书文件路径（fullchain） |
| `MCP_TLS_KEY` | TLS 私钥文件路径 |

## 使用方式

```bash
PUBLIC_ORIGIN=https://your-domain.com MCP_TLS_CERT=/path/to/fullchain.cer MCP_TLS_KEY=/path/to/key npm start
```

## 架构

```
claude.ai ──HTTPS──▶ VPS frps ──TCP──▶ frpc ──TCP──▶ localhost:9999 (HTTPS, gatekeeper 自签 TLS)
```

FRP 做纯 TCP 隧道，不处理 TLS。gatekeeper 用本地证书直接提供 HTTPS。